### PR TITLE
support RISC-V

### DIFF
--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -479,6 +479,10 @@
 #   define NONSTOP
 #   define mach_type_known
 # endif
+# if defined(__riscv) && defined(LINUX)
+#   define RISCV
+#   define mach_type_known
+# endif
 
 /* Feel free to add more clauses here */
 
@@ -1318,6 +1322,19 @@
 #      define NO_PTHREAD_TRYLOCK
 #   endif /* DARWIN */
 # endif
+
+# ifdef RISCV
+#   define MACH_TYPE "RISC-V"
+#   define CPP_WORDSZ __riscv_xlen /* 32 or 64 */
+#   define ALIGNMENT (CPP_WORDSZ/8)
+#   ifdef LINUX
+#     define OS_TYPE "LINUX"
+      extern int __data_start[];
+#     define DATASTART ((ptr_t)__data_start)
+#     define LINUX_STACKBOTTOM
+#     define DYNAMIC_LOADING
+#   endif
+# endif /* RISCV */
 
 # ifdef NS32K
 #   define MACH_TYPE "NS32K"


### PR DESCRIPTION
fix https://github.com/uim/sigscheme/issues/8.

imported from:

* https://github.com/ivmai/bdwgc/commit/4f7f0eebd24dcde9f2b3ec2cb98913fc39bbdda3
* https://github.com/ivmai/bdwgc/commit/3b008f79ee29dbd0d61cf163d20eee21412df95b

tested by sigscheme's `runtest.sh` and `runtest-tail-rec.sh` at Fedora 28 (QEMU).